### PR TITLE
Include `node.text` when helpful

### DIFF
--- a/test-support/helpers/a11y/helpers/actions.js
+++ b/test-support/helpers/a11y/helpers/actions.js
@@ -26,7 +26,7 @@ if (!Element.prototype.matches) {
     let el = this;
     let matches = (el.document || el.ownerDocument).querySelectorAll(selector);
     let i = 0;
-    
+
     while (matches[i] && matches[i] !== el) {
       i++;
     }
@@ -44,7 +44,7 @@ if (!Element.prototype.matches) {
  */
 export function actionIsFocusable(app, el) {
   if (!FOCUS_SELECTORS.filter((selector) => el.matches(selector)).length) {
-    throw new A11yError(`The action on ${el} is inaccessible, since the element does not receive focus.`);
+    throw new A11yError(`The action on "${el.text}" is inaccessible, since the element does not receive focus.`);
   }
 
   return true;

--- a/test-support/helpers/a11y/helpers/alt-text.js
+++ b/test-support/helpers/a11y/helpers/alt-text.js
@@ -20,7 +20,7 @@ export function hasAltText(app, el) {
     return true;
   }
 
-  throw new A11yError(`${el} has no alt text. Either add an alt description or add the aria-hidden attribute.`);
+  throw new A11yError(`"${el.src || el.text}" has no alt text. Either add an alt description or add the aria-hidden attribute.`);
 }
 
 /**

--- a/test-support/helpers/a11y/helpers/aria-properties.js
+++ b/test-support/helpers/a11y/helpers/aria-properties.js
@@ -18,7 +18,7 @@ import { ARIA_MAP, GLOBAL_ARIA } from '../utils/wai-aria-map';
  */
 function checkAriaProp(el, prop) {
   if (el.getAttribute(`aria-${prop}`) === null) {
-    throw new A11yError(`${el} is required to have the attribute 'aria-${prop}' when using role='${el.getAttribute('role')}'.`);
+    throw new A11yError(`"${el.text}" is required to have the attribute 'aria-${prop}' when using role='${el.getAttribute('role')}'.`);
   }
 
   return true;
@@ -100,7 +100,7 @@ export function verifySupportedAria(app, el) {
 
     ariaAttributes.forEach((item) => {
       if (supportedAttributes.indexOf(item) === -1) {
-        throw new A11yError(`The attribute 'aria-${item}' is not a supported ARIA property/state for '${role}'; you should remove it from ${el}`);
+        throw new A11yError(`The attribute 'aria-${item}' is not a supported ARIA property/state for '${role}'; you should remove it from "${el.text}"`);
       }
     });
   }

--- a/test-support/helpers/a11y/helpers/color-contrast.js
+++ b/test-support/helpers/a11y/helpers/color-contrast.js
@@ -74,7 +74,7 @@ function resetTestingContainer() {
  * their contrast ratio to ensure accessibility
  * @param {Object} app - Not used
  * @param {String} level - The level of conformance to check, defaults to 'AA'
- * @return {Boolean|Error} 
+ * @return {Boolean|Error}
  */
 export function checkAllTextContrast(app, level) {
   // Set the conformance level we plan to check
@@ -155,7 +155,7 @@ export function checkAllTextContrast(app, level) {
  * @param {Object} app - Not used
  * @param {HTMLElement} text
  * @param {HTMLElement} background (optional)
- * @return {Boolean|Error} 
+ * @return {Boolean|Error}
  */
 export function checkTextContrast(app, text, background=text, level='AA') {
   let testingContainer = document.getElementById('ember-testing');
@@ -177,7 +177,7 @@ export function checkTextContrast(app, text, background=text, level='AA') {
   testingContainer.style.zoom = null;
 
   if (!result) {
-    throw new A11yError(`The contrast between ${text} and ${background} is lower than expected for ${level} standards`);
+    throw new A11yError(`The contrast between "${text.text}" and ${background} is lower than expected for ${level} standards`);
   }
 
   return result;

--- a/test-support/helpers/a11y/helpers/form-labels.js
+++ b/test-support/helpers/a11y/helpers/form-labels.js
@@ -25,7 +25,7 @@ function needsLabel(tag, type) {
  * @return {Boolean|Error}
  */
 function verifyLabel(el) {
-  let ariaBy = el.getAttribute('aria-describedby') || 
+  let ariaBy = el.getAttribute('aria-describedby') ||
                el.getAttribute('aria-labelledby');
 
   if (ariaBy) {
@@ -48,7 +48,7 @@ function verifyAriaLabel(el, ariaBy) {
   for (let i = 0, l = ids.length; i < l; i++) {
     let label = document.getElementById(ids[i])
     if (!label) {
-      throw new A11yError(`${el} is missing the element it is associated with ID ${ids[i]}`);
+      throw new A11yError(`"${el.text}" is missing the element it is associated with ID ${ids[i]}`);
     } else if (!label.innerHTML) {
       throw new A11yError(`The label with ID ${ids[i]} has no content. You should add content to make this label useful.`);
     }
@@ -66,15 +66,15 @@ function verifyNonAriaLabel(el) {
   let elementId = el.id;
 
   if (!elementId) {
-    throw new A11yError(`${el} has no ID, describedby, or labelledby attribute. You should add one to associate it with a label.`);
+    throw new A11yError(`"${el.text}" has no ID, describedby, or labelledby attribute. You should add one to associate it with a label.`);
   }
 
   let label = document.querySelector(`[for="${elementId}"]`);
 
   if (!label) {
-    throw new A11yError(`${el} has an ID but no associated label. You should add a label and reference this element via the for attribute`);
+    throw new A11yError(`"${el.text}" has an ID but no associated label. You should add a label and reference this element via the for attribute`);
   } else if (!label.innerHTML) {
-    throw new A11yError(`The label for ${el} has no content. You should add content to make this label useful.`);
+    throw new A11yError(`The label for "${el.text}" has no content. You should add content to make this label useful.`);
   }
 
   return true;

--- a/test-support/helpers/a11y/helpers/links.js
+++ b/test-support/helpers/a11y/helpers/links.js
@@ -26,7 +26,7 @@ function isBadHref(href) {
 
 export function checkLinkForMerge(app, link) {
   if (link.nextElementSibling && link.nextElementSibling.href === link.href) {
-    throw new A11yError(`${link} and ${link.nextElementSibling} should be merged together since they are adjacent and point to the same link.`);
+    throw new A11yError(`"${link.text}" and "${link.nextElementSibling.text}" should be merged together since they are adjacent and point to the same link.`);
   }
 
   return true;
@@ -34,7 +34,7 @@ export function checkLinkForMerge(app, link) {
 
 export function checkLinkHref(app, link) {
   if (isBadHref(link.href)) {
-    throw new A11yError(`${link} has a non-meaningful href, it should point to an actual link.`);
+    throw new A11yError(`"${link.text}" has a non-meaningful href, it should point to an actual link.`);
   }
 
   return true;
@@ -46,13 +46,13 @@ export function checkLinkText(app, link) {
 
     if (image) {
       if (!image.alt) {
-        throw new A11yError(`${image} in ${link} should have alt text`);
+        throw new A11yError(`${image.src} in "${link.text}" should have alt text`);
       }
 
       return true;
     }
 
-    throw new A11yError(`${link} has no textual content, you should add some to give the link meaning.`);
+    throw new A11yError(`"${link.text}" has no textual content, you should add some to give the link meaning.`);
   }
 
   return true;


### PR DESCRIPTION
Without specifying `node.text`, error messages might not always contain
helpful information.

For example, the following was raised for an `<a>` tag without an `href`:

```
A11yError:  has a non-meaningful href, it should point to an actual
link.
```

When `${node}` replaced with `${node.text}`, the following was produced:

```
A11yError: "Waiting for a submission..." has a non-meaningful href, it
should point to an actual link.
```