### PR TITLE
Accept `<label><input></label>`

### DIFF
--- a/test-support/helpers/a11y/helpers/form-labels.js
+++ b/test-support/helpers/a11y/helpers/form-labels.js
@@ -3,6 +3,7 @@
  * Reference: http://www.w3.org/TR/WCAG20/#minimize-error
  */
 
+import Ember from 'ember';
 import A11yError from '../a11y-error';
 
 // Define the types of input elements that require a label
@@ -63,7 +64,7 @@ function verifyAriaLabel(el, ariaBy) {
  * @return {Boolean|Error}
  */
 function verifyNonAriaLabel(el) {
-  if (el.parentNode.tagName === 'LABEL') {
+  if (Ember.$(el).parents('label').length > 0) {
     return true;
   }
 

--- a/test-support/helpers/a11y/helpers/form-labels.js
+++ b/test-support/helpers/a11y/helpers/form-labels.js
@@ -25,7 +25,7 @@ function needsLabel(tag, type) {
  * @return {Boolean|Error}
  */
 function verifyLabel(el) {
-  let ariaBy = el.getAttribute('aria-describedby') || 
+  let ariaBy = el.getAttribute('aria-describedby') ||
                el.getAttribute('aria-labelledby');
 
   if (ariaBy) {
@@ -63,6 +63,10 @@ function verifyAriaLabel(el, ariaBy) {
  * @return {Boolean|Error}
  */
 function verifyNonAriaLabel(el) {
+  if (el.parentNode.tagName === 'LABEL') {
+    return true;
+  }
+
   let elementId = el.id;
 
   if (!elementId) {

--- a/tests/acceptance/form-labels-test.js
+++ b/tests/acceptance/form-labels-test.js
@@ -30,11 +30,11 @@ test('hasLabel passes with actual label', function(assert) {
   });
 });
 
-test('hasLabel passes when input is child of label', function(assert) {
+test('hasLabel passes when input has label ancestor', function(assert) {
   visit('/form-labels');
 
   andThen(function() {
-    let input = find('#wrapping-label input')[0];
+    let input = find('#input-with-label-ancestor input')[0];
     assert.ok(hasLabel(input));
   });
 });

--- a/tests/acceptance/form-labels-test.js
+++ b/tests/acceptance/form-labels-test.js
@@ -30,6 +30,15 @@ test('hasLabel passes with actual label', function(assert) {
   });
 });
 
+test('hasLabel passes when input is child of label', function(assert) {
+  visit('/form-labels');
+
+  andThen(function() {
+    let input = find('#wrapping-label input')[0];
+    assert.ok(hasLabel(input));
+  });
+});
+
 test('hasLabel fails due to no ID', function(assert) {
   visit('/form-labels');
 
@@ -131,7 +140,7 @@ test('hasLabel fails with one bad label in when aria-describedby has multiple ID
 
 /* hasLabel without having actual labels */
 
-test('hasLabel passs on button with content', function(assert) {
+test('hasLabel passes on button with content', function(assert) {
   visit('/form-labels');
 
   andThen(function() {

--- a/tests/dummy/app/templates/form-labels.hbs
+++ b/tests/dummy/app/templates/form-labels.hbs
@@ -34,8 +34,10 @@
   <span id="address-description">Address</span>
   <input type="text" id="address" aria-describedby="address-description">
 
-  <label id="wrapping-label">
-    <input type="text" name="email">
+  <label id="input-with-label-ancestor">
+    <div>
+      <input type="checkbox" name="remember-me">
+    </div>
   </label>
 
   <input type="submit" value="Submit">

--- a/tests/dummy/app/templates/form-labels.hbs
+++ b/tests/dummy/app/templates/form-labels.hbs
@@ -34,5 +34,9 @@
   <span id="address-description">Address</span>
   <input type="text" id="address" aria-describedby="address-description">
 
+  <label id="wrapping-label">
+    <input type="text" name="email">
+  </label>
+
   <input type="submit" value="Submit">
 </form>


### PR DESCRIPTION
From the [Google Chrome accessibility developer tools][chrome]:

```html
<!-- Good: using label-wrapped -->
<!-- In this case both "Address:" and the contents of the text field will be read. -->
<label>
  Address:
  <input>
</label>
```

[chrome]: https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#controls-and-media-elements-should-have-labels