### PR TITLE
Allow `<form>` elements to have `{{action}}`

### DIFF
--- a/test-support/helpers/a11y/helpers/actions.js
+++ b/test-support/helpers/a11y/helpers/actions.js
@@ -14,11 +14,17 @@ const FOCUS_SELECTORS = [
   'a[href]',
   'area[href]',
   'iframe',
-  '[tabindex]:not([tabindex="-1"])'
+  '[tabindex]:not([tabindex="-1"])',
+];
+
+const FOCUS_EXCEPTIONS = [
+  'form',
 ];
 
 // Selector to find any Ember-bound actions
 const ACTION_SELECTOR = '[data-ember-action]';
+
+const MATCHES = (el) => (selector) => el.matches(selector);
 
 // Add polyfill for browsers that don't have Element.matches (including Phantom)
 if (!Element.prototype.matches) {
@@ -43,7 +49,8 @@ if (!Element.prototype.matches) {
  * @return {Boolean|Error}
  */
 export function actionIsFocusable(app, el) {
-  if (!FOCUS_SELECTORS.filter((selector) => el.matches(selector)).length) {
+  if (!FOCUS_SELECTORS.filter(MATCHES(el)).length &&
+      !FOCUS_EXCEPTIONS.filter(MATCHES(el)).length) {
     throw new A11yError(el, `The action on the element is inaccessible, since the element does not receive focus.`);
   }
 

--- a/tests/acceptance/actions-test.js
+++ b/tests/acceptance/actions-test.js
@@ -30,6 +30,9 @@ test('actionIsFocusable passes', function(assert) {
 
     let focusableByTabindex = find('#focusable-by-tabindex')[0];
     assert.ok(actionIsFocusable(focusableByTabindex));
+
+    let formWithAction = find('form')[0];
+    assert.ok(actionIsFocusable(formWithAction));
   });
 });
 

--- a/tests/dummy/app/templates/actions.hbs
+++ b/tests/dummy/app/templates/actions.hbs
@@ -1,3 +1,7 @@
 <button id="focusable-by-default" {{action "test"}}></button>
 <span id="focusable-by-tabindex" tabindex="0" {{action "test"}}></span>
 <a id="not-focusable" {{action "test"}}></a>
+
+<form {{action "test" on="submit"}}>
+  <input type="submit">
+</form>


### PR DESCRIPTION
Form elements can have [actions triggered by submit][submit]:

```hbs
<form {{action "save" on="submit"}}`>
</form>
```

[submit]: https://github.com/emberjs/ember.js/blob/1a2cd166a86219717a0cde1df4dab497d8dda3e3/packages/ember-routing-htmlbars/lib/keywords/element-action.js#L51