### PR TITLE
Log `A11yError` element

### DIFF
--- a/test-support/helpers/a11y/a11y-error.js
+++ b/test-support/helpers/a11y/a11y-error.js
@@ -1,6 +1,8 @@
-function A11yError(message='accessibility error') {
+function A11yError(element, message='accessibility error') {
   this.name = 'A11yError';
+  this.element = element;
   this.message = message;
+  this.stack = (new Error()).stack;
 }
 
 A11yError.prototype = Object.create(Error.prototype);

--- a/test-support/helpers/a11y/helpers/actions.js
+++ b/test-support/helpers/a11y/helpers/actions.js
@@ -26,7 +26,7 @@ if (!Element.prototype.matches) {
     let el = this;
     let matches = (el.document || el.ownerDocument).querySelectorAll(selector);
     let i = 0;
-    
+
     while (matches[i] && matches[i] !== el) {
       i++;
     }
@@ -44,7 +44,7 @@ if (!Element.prototype.matches) {
  */
 export function actionIsFocusable(app, el) {
   if (!FOCUS_SELECTORS.filter((selector) => el.matches(selector)).length) {
-    throw new A11yError(`The action on ${el} is inaccessible, since the element does not receive focus.`);
+    throw new A11yError(el, `The action on the element is inaccessible, since the element does not receive focus.`);
   }
 
   return true;

--- a/test-support/helpers/a11y/helpers/alt-text.js
+++ b/test-support/helpers/a11y/helpers/alt-text.js
@@ -20,7 +20,7 @@ export function hasAltText(app, el) {
     return true;
   }
 
-  throw new A11yError(`${el} has no alt text. Either add an alt description or add the aria-hidden attribute.`);
+  throw new A11yError(el, `The element has no alt text. Either add an alt description or add the aria-hidden attribute.`);
 }
 
 /**

--- a/test-support/helpers/a11y/helpers/aria-properties.js
+++ b/test-support/helpers/a11y/helpers/aria-properties.js
@@ -18,7 +18,7 @@ import { ARIA_MAP, GLOBAL_ARIA } from '../utils/wai-aria-map';
  */
 function checkAriaProp(el, prop) {
   if (el.getAttribute(`aria-${prop}`) === null) {
-    throw new A11yError(`${el} is required to have the attribute 'aria-${prop}' when using role='${el.getAttribute('role')}'.`);
+    throw new A11yError(el, `The element is required to have the attribute 'aria-${prop}' when using role='${el.getAttribute('role')}'.`);
   }
 
   return true;
@@ -34,7 +34,7 @@ function getAriaRole(el) {
   let role = el.getAttribute('role');
 
   if (role && !ARIA_MAP[role]) {
-    throw new A11yError(`The role '${role}' is not a valid role. You should remove it.`);
+    throw new A11yError(el, `The role '${role}' is not a valid role. You should remove it.`);
   }
 
   return role;
@@ -100,7 +100,7 @@ export function verifySupportedAria(app, el) {
 
     ariaAttributes.forEach((item) => {
       if (supportedAttributes.indexOf(item) === -1) {
-        throw new A11yError(`The attribute 'aria-${item}' is not a supported ARIA property/state for '${role}'; you should remove it from ${el}`);
+        throw new A11yError(el, `The attribute 'aria-${item}' is not a supported ARIA property/state for '${role}'; you should remove it`);
       }
     });
   }

--- a/test-support/helpers/a11y/helpers/color-contrast.js
+++ b/test-support/helpers/a11y/helpers/color-contrast.js
@@ -74,7 +74,7 @@ function resetTestingContainer() {
  * their contrast ratio to ensure accessibility
  * @param {Object} app - Not used
  * @param {String} level - The level of conformance to check, defaults to 'AA'
- * @return {Boolean|Error} 
+ * @return {Boolean|Error}
  */
 export function checkAllTextContrast(app, level) {
   // Set the conformance level we plan to check
@@ -131,7 +131,7 @@ export function checkAllTextContrast(app, level) {
 
     // Check if the background is a background-image
     if (window.getComputedStyle(background).backgroundImage !== 'none') {
-      console.warn(`${node} has a background-image for its background, be careful that the contrast ratio is still accessible`);
+      console.warn(node, `has a background-image for its background, be careful that the contrast ratio is still accessible`);
       continue;
     }
 
@@ -155,7 +155,7 @@ export function checkAllTextContrast(app, level) {
  * @param {Object} app - Not used
  * @param {HTMLElement} text
  * @param {HTMLElement} background (optional)
- * @return {Boolean|Error} 
+ * @return {Boolean|Error}
  */
 export function checkTextContrast(app, text, background=text, level='AA') {
   let testingContainer = document.getElementById('ember-testing');
@@ -177,7 +177,7 @@ export function checkTextContrast(app, text, background=text, level='AA') {
   testingContainer.style.zoom = null;
 
   if (!result) {
-    throw new A11yError(`The contrast between ${text} and ${background} is lower than expected for ${level} standards`);
+    throw new A11yError([text, background], `The contrast between the foreground and background is lower than expected for ${level} standards`);
   }
 
   return result;

--- a/test-support/helpers/a11y/helpers/form-labels.js
+++ b/test-support/helpers/a11y/helpers/form-labels.js
@@ -25,7 +25,7 @@ function needsLabel(tag, type) {
  * @return {Boolean|Error}
  */
 function verifyLabel(el) {
-  let ariaBy = el.getAttribute('aria-describedby') || 
+  let ariaBy = el.getAttribute('aria-describedby') ||
                el.getAttribute('aria-labelledby');
 
   if (ariaBy) {
@@ -48,9 +48,9 @@ function verifyAriaLabel(el, ariaBy) {
   for (let i = 0, l = ids.length; i < l; i++) {
     let label = document.getElementById(ids[i])
     if (!label) {
-      throw new A11yError(`${el} is missing the element it is associated with ID ${ids[i]}`);
+      throw new A11yError(el, `The element is missing the element it is associated with ID ${ids[i]}`);
     } else if (!label.innerHTML) {
-      throw new A11yError(`The label with ID ${ids[i]} has no content. You should add content to make this label useful.`);
+      throw new A11yError(el, `The label with ID ${ids[i]} has no content. You should add content to make this label useful.`);
     }
   }
 
@@ -66,15 +66,15 @@ function verifyNonAriaLabel(el) {
   let elementId = el.id;
 
   if (!elementId) {
-    throw new A11yError(`${el} has no ID, describedby, or labelledby attribute. You should add one to associate it with a label.`);
+    throw new A11yError(el, `The element has no ID, describedby, or labelledby attribute. You should add one to associate it with a label.`);
   }
 
   let label = document.querySelector(`[for="${elementId}"]`);
 
   if (!label) {
-    throw new A11yError(`${el} has an ID but no associated label. You should add a label and reference this element via the for attribute`);
+    throw new A11yError(el, `The element has an ID but no associated label. You should add a label and reference this element via the for attribute`);
   } else if (!label.innerHTML) {
-    throw new A11yError(`The label for ${el} has no content. You should add content to make this label useful.`);
+    throw new A11yError(el, `The label for the element has no content. You should add content to make this label useful.`);
   }
 
   return true;
@@ -95,12 +95,12 @@ export function hasLabel(app, el) {
   } else if (tagName === 'INPUT' && (type === 'submit' || type === 'button')) {
     // Input is a submit button, there it should have a value set
     if (!el.value) {
-      throw new A11yError(`${el} has no value and is a ${type} input. You should add a value to the input so it has valuable meaning.`);
+      throw new A11yError(el, `The element has no value and is a ${type} input. You should add a value to the input so it has valuable meaning.`);
     }
   } else if (tagName === 'BUTTON') {
     // Element is a button, should have some inner content to describe it
     if (!el.innerHTML) {
-      throw new A11yError(`${el} has no inner content and is a button. You should add some content to give the button textual meaning.`);
+      throw new A11yError(el, `The element has no inner content and is a button. You should add some content to give the button textual meaning.`);
     }
   }
 

--- a/test-support/helpers/a11y/helpers/id-checks.js
+++ b/test-support/helpers/a11y/helpers/id-checks.js
@@ -33,7 +33,7 @@ function checkMultipleIds(els) {
   let multiIds = els.filter((el) => el.id.trim().split(/\s+/).length > 1);
 
   if (multiIds.length) {
-    throw new A11yError(`${multiIds[0]} has multiple IDs; you should remove all but one of those.`);
+    throw new A11yError(els, `${multiIds[0]} has multiple IDs; you should remove all but one of those.`);
   }
 
   return true
@@ -49,7 +49,7 @@ function checkIdDuplicates(els) {
   let duplicate = hasDuplicates(ids);
 
   if (duplicate) {
-    throw new A11yError(`The ID '${duplicate}' is used more than once; you should only use each ID once.`);
+    throw new A11yError(duplicate, `The ID '${duplicate}' is used more than once; you should only use each ID once.`);
   }
 
   return true;

--- a/test-support/helpers/a11y/helpers/links.js
+++ b/test-support/helpers/a11y/helpers/links.js
@@ -26,7 +26,7 @@ function isBadHref(href) {
 
 export function checkLinkForMerge(app, link) {
   if (link.nextElementSibling && link.nextElementSibling.href === link.href) {
-    throw new A11yError(`${link} and ${link.nextElementSibling} should be merged together since they are adjacent and point to the same link.`);
+    throw new A11yError([link, link.nextElementSibling], `The element and its sibling should be merged together since they are adjacent and point to the same link.`);
   }
 
   return true;
@@ -34,7 +34,7 @@ export function checkLinkForMerge(app, link) {
 
 export function checkLinkHref(app, link) {
   if (isBadHref(link.href)) {
-    throw new A11yError(`${link} has a non-meaningful href, it should point to an actual link.`);
+    throw new A11yError(link, `The element has a non-meaningful href, it should point to an actual link.`);
   }
 
   return true;
@@ -46,13 +46,13 @@ export function checkLinkText(app, link) {
 
     if (image) {
       if (!image.alt) {
-        throw new A11yError(`${image} in ${link} should have alt text`);
+        throw new A11yError([image, link], `The image in the link should have alt text`);
       }
 
       return true;
     }
 
-    throw new A11yError(`${link} has no textual content, you should add some to give the link meaning.`);
+    throw new A11yError(link, `The element has no textual content, you should add some to give the link meaning.`);
   }
 
   return true;

--- a/test-support/helpers/a11y/helpers/no-read.js
+++ b/test-support/helpers/a11y/helpers/no-read.js
@@ -36,11 +36,11 @@ export function checkAriaHidden(app, el, throwError) {
     // Should have aria-hidden=true
     let ariaHidden = el.getAttribute('aria-hidden');
     if (ariaHidden !== 'true') {
-      let message = `${el} has no content yet is visible, it should probably have aria-hidden="true" set.`;
+      let message = `The element has no content yet is visible, it should probably have aria-hidden="true" set.`;
       if (throwError) {
-        throw new A11yError(message);
+        throw new A11yError(el, message);
       } else {
-        console.warn(message);
+        console.warn(el, message);
       }
     }
   }

--- a/test-support/helpers/a11y/register-a11y-helpers.js
+++ b/test-support/helpers/a11y/register-a11y-helpers.js
@@ -43,7 +43,15 @@ function a11yTest(app, config) {
   TEST_FUNCTIONS.forEach(function(testFn) {
     let testVal = config[testFn.name];
     if (testVal) {
-      testFn(null, testVal);
+      try {
+        testFn(null, testVal);
+      } catch(error) {
+        if (error.element) {
+          console.error(error.element, error.message);
+        }
+
+        throw error;
+      }
     }
   });
 


### PR DESCRIPTION
Closes [#2].

When throwing an `A11yError`, include the element separately from the
message.

Then, during `a11yTest` invocation, catch the error, log it to the
console, then rethrow.

Ensure the error [preserves the current frame's stack trace][mozilla].

[#2]: https://github.com/trentmwillis/ember-a11y-testing/issues/2
[mozilla]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types