### PR TITLE
Do not throw error if alt tag is present but empty

### DIFF
--- a/test-support/helpers/a11y/helpers/alt-text.js
+++ b/test-support/helpers/a11y/helpers/alt-text.js
@@ -12,7 +12,7 @@ import A11yError from '../a11y-error';
  * @return {Boolean|Error}
  */
 export function hasAltText(app, el) {
-  let altText = el && el.getAttribute('alt');
+  let altText = el && el.hasAttribute('alt');
   let ariaHidden = el && el.getAttribute('aria-hidden');
   let presentation = el && el.getAttribute('role') === 'presentation';
 

--- a/tests/acceptance/a11y-test-test.js
+++ b/tests/acceptance/a11y-test-test.js
@@ -26,7 +26,7 @@ test('a11yTest runs all tests with default values', function(assert) {
     assert.ok(a11yTest());
 
     let imageWithAltText = find('#alt-text')[0];
-    imageWithAltText.setAttribute('alt', '');
+    imageWithAltText.removeAttribute('alt');
     assert.throws(function() {
       a11yTest();
     }, /A11yError/);
@@ -52,7 +52,7 @@ test('a11yTest does not run tests with falsy config values', function(assert) {
 
   andThen(function() {
     let imageWithAltText = find('#alt-text')[0];
-    imageWithAltText.setAttribute('alt', '');
+    imageWithAltText.removeAttribute('alt');
     assert.ok(a11yTest({ allImagesHaveAltText: false }));
     assert.throws(function() {
       a11yTest();

--- a/tests/acceptance/alt-text-test.js
+++ b/tests/acceptance/alt-text-test.js
@@ -28,6 +28,15 @@ test('hasAltText passes', function(assert) {
   });
 });
 
+test('hasAltText passes for empty alt attribute', function(assert) {
+  visit('/alt-text');
+
+  andThen(function() {
+    let altText = find('#empty-alt-text')[0];
+    assert.ok(hasAltText(altText));
+  });
+});
+
 test('hasAltText passes with aria-hidden', function(assert) {
   visit('/alt-text');
 

--- a/tests/dummy/app/templates/alt-text.hbs
+++ b/tests/dummy/app/templates/alt-text.hbs
@@ -1,4 +1,5 @@
-<img id="no-alt-text" alt="">
+<img id="no-alt-text">
+<img id="empty-alt-text" alt="">
 <img id="alt-text" alt="Has alt text">
 <img id="aria-hidden" aria-hidden="true">
 <img id="presentation" role="presentation">


### PR DESCRIPTION
Right now, if you have an empty alt-attribute, an error is thrown:

```html
<img src="myimage.jpg" alt="">
```

However, elements are actually allowed to have an empty alt-attribute if they are truly decorative:
http://www.w3.org/TR/WCAG20-TECHS/H67.html

Note the difference between having an empty alt-attribute and no alt-attribute at all.

I changed the check from `getAttribute("alt")` to `hasAttribute("alt")`. I also adapted the tests to reflect this behaviour and added a new test for this use case.