### PR TITLE
Add installation notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ framework. The goal is to help pick up on completely avoidable accessibility
 issues (such as alt text for images, labels in forms, and color contrast) during
 your testing pipeline.
 
+## Installation
+
+Within your Ember app, use the [Ember CLI](http://ember-cli.com/) to install this test suite as an add-on:
+
+```bash
+ember install ember-a11y-testing
+```
+
 ## Usage
 
 There are two ways to use this add-on:
@@ -21,7 +29,7 @@ modules on your page meet a specific requirement.
 
 To run an entire suite of a11y tests, simply call the `a11yTest` method from
 inside one of your assertions. If all tests pass, it will return `true` (making
-it easy to assert against); otherwise, an error gets thrown (and occassionally,
+it easy to assert against); otherwise, an error gets thrown (and occasionally,
 a `console.warn`).
 
 **Example:**


### PR DESCRIPTION
Hello :wave:

Awesome tool for Ember, thank you :sparkles: 

I had a spot of trouble figuring out how to get these tests in my Ember app this week. Partly due to myself not being used to the "everything is an add-on" kinda mantra in the Ember eco-system. I haven't installed a lot of add-ons up to this point. A suite of tests doesn't really feel like a plugin you'd install which I think threw me at first. I figured it out after going through some of the metadata files in the repo.

I thought I probably won't be the only one who might feel lost, so I am proposing to add an installation section to the README. I hope you'll see it as a useful addition :grin:

This test suite has already picked up on some issues in our very young Ember app, so thank you again. A11y is something I am really passionate about.

