### PR TITLE
Check for alt attribute on all non-text elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Below are the tests and options that run in the `a11yTest` suite. By default,
 all tests run with a config value of `true`; they can be disabled by passing in
 `false` in their configuration.
 
-### `allImagesHaveAltText`
-Checks all images on the page to ensure they have `alt` text or that they have
+### `allNonTextElementsHaveAltText`
+Checks all non-text elements (img, audio, video, embed, object and canvas) on the page to ensure they have `alt` text or that they have
 `aria-hidden="true"`/`role="presentation"`.
 
 ### `checkForNoRead`
@@ -141,4 +141,3 @@ this list.
 - [ ] Verify relationship of ARIA roles (radiogroup - radio, list - listitem,
 etc.)
 - [ ] Verify element is allowed to have ARIA attribute/role
-- [ ] Alternative text for other elements (e.g., `object`, `embed`)

--- a/test-support/helpers/a11y/helpers/alt-text.js
+++ b/test-support/helpers/a11y/helpers/alt-text.js
@@ -37,6 +37,7 @@ export function hasAltText(app, el) {
  * Checks all <img> elements on the page to make sure they have alt text
  * @return {Boolean|Error}
  */
+// TODO: Prior to releasing 1.0, remove this method in favor of using allNonTextElementsHaveAltText as default
 export function allImagesHaveAltText() {
   let images = document.querySelectorAll('img');
 
@@ -46,7 +47,6 @@ export function allImagesHaveAltText() {
 
   return true;
 }
-
 
 /**
  * Checks all non-text elements (including images) on the page to make sure they have alt text

--- a/test-support/helpers/a11y/helpers/alt-text.js
+++ b/test-support/helpers/a11y/helpers/alt-text.js
@@ -5,6 +5,16 @@
 
 import A11yError from '../a11y-error';
 
+// Selectors for all non-text elements that should have text alternatives in the form of an alt attribute
+const ALT_SELECTORS = [
+  'audio',
+  'embed',
+  'object',
+  'canvas',
+  'img',
+  'video'
+];
+
 /**
  * Checks a specific element to make sure it has alt text
  * @param {Object} app - Not used
@@ -32,6 +42,21 @@ export function allImagesHaveAltText() {
 
   for (let i = 0, l = images.length; i < l; i++) {
     hasAltText(null, images[i]);
+  }
+
+  return true;
+}
+
+
+/**
+ * Checks all non-text elements (including images) on the page to make sure they have alt text
+ * @return {Boolean|Error}
+ */
+export function allNonTextElementsHaveAltText() {
+  let elements = document.querySelectorAll(ALT_SELECTORS.join(','));
+
+  for (let i = 0, l = elements.length; i < l; i++) {
+    hasAltText(null, elements[i]);
   }
 
   return true;

--- a/test-support/helpers/a11y/register-a11y-helpers.js
+++ b/test-support/helpers/a11y/register-a11y-helpers.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-import { hasAltText, allImagesHaveAltText } from './helpers/alt-text';
+import { hasAltText, allImagesHaveAltText, allNonTextElementsHaveAltText } from './helpers/alt-text';
 import { isAllowedFocus, allAreAllowedFocus } from './helpers/focusable-visibility';
 import { checkAriaHidden, checkForNoRead } from './helpers/no-read';
 import { hasLabel, formHasAllNeededLabels, allFormsHaveLabels } from './helpers/form-labels';
@@ -12,6 +12,7 @@ import { actionIsFocusable, allActionsFocusable } from './helpers/actions';
 
 const TEST_FUNCTIONS = [
   allImagesHaveAltText,
+  allNonTextElementsHaveAltText,
   checkForNoRead,
   checkAriaRoles,
   allFormsHaveLabels,
@@ -24,7 +25,7 @@ const TEST_FUNCTIONS = [
 ];
 
 const DEFAULT_CONFIG = {
-  allImagesHaveAltText: true,
+  allNonTextElementsHaveAltText: true,
   checkForNoRead: true,
   checkAriaRoles: true,
   allFormsHaveLabels: true,
@@ -69,6 +70,7 @@ export default function registerA11yHelpers() {
   // alt-text
   Ember.Test.registerHelper('hasAltText', hasAltText);
   Ember.Test.registerHelper('allImagesHaveAltText', allImagesHaveAltText);
+  Ember.Test.registerHelper('allNonTextElementsHaveAltText', allNonTextElementsHaveAltText);
 
   // no-read
   Ember.Test.registerHelper('checkAriaHidden', checkAriaHidden);

--- a/test-support/helpers/a11y/register-a11y-helpers.js
+++ b/test-support/helpers/a11y/register-a11y-helpers.js
@@ -25,6 +25,7 @@ const TEST_FUNCTIONS = [
 ];
 
 const DEFAULT_CONFIG = {
+  allImagesHaveAltText: false,
   allNonTextElementsHaveAltText: true,
   checkForNoRead: true,
   checkAriaRoles: true,

--- a/tests/acceptance/a11y-test-test.js
+++ b/tests/acceptance/a11y-test-test.js
@@ -53,7 +53,7 @@ test('a11yTest does not run tests with falsy config values', function(assert) {
   andThen(function() {
     let imageWithAltText = find('#alt-text')[0];
     imageWithAltText.removeAttribute('alt');
-    assert.ok(a11yTest({ allImagesHaveAltText: false }));
+    assert.ok(a11yTest({ allImagesHaveAltText: false, allNonTextElementsHaveAltText: false }));
     assert.throws(function() {
       a11yTest();
     }, /A11yError/);

--- a/tests/acceptance/alt-text-test.js
+++ b/tests/acceptance/alt-text-test.js
@@ -1,4 +1,4 @@
-/* global hasAltText, allImagesHaveAltText */
+/* global hasAltText, allImagesHaveAltText, allNonTextElementsHaveAltText */
 
 import Ember from 'ember';
 import {
@@ -23,7 +23,7 @@ test('hasAltText passes', function(assert) {
   visit('/alt-text');
 
   andThen(function() {
-    let altText = find('#alt-text')[0];
+    let altText = find('#img-alt-text')[0];
     assert.ok(hasAltText(altText));
   });
 });
@@ -32,7 +32,7 @@ test('hasAltText passes for empty alt attribute', function(assert) {
   visit('/alt-text');
 
   andThen(function() {
-    let altText = find('#empty-alt-text')[0];
+    let altText = find('#img-empty-alt-text')[0];
     assert.ok(hasAltText(altText));
   });
 });
@@ -41,7 +41,7 @@ test('hasAltText passes with aria-hidden', function(assert) {
   visit('/alt-text');
 
   andThen(function() {
-    let ariaHidden = find('#aria-hidden')[0];
+    let ariaHidden = find('#img-aria-hidden')[0];
     assert.ok(hasAltText(ariaHidden));
   });
 });
@@ -50,7 +50,7 @@ test('hasAltText passes with presentation role', function(assert) {
   visit('/alt-text');
 
   andThen(function() {
-    let presentationRole = find('#presentation')[0];
+    let presentationRole = find('#img-presentation')[0];
     assert.ok(hasAltText(presentationRole));
   });
 });
@@ -59,7 +59,7 @@ test('hasAltText throws error', function(assert) {
   visit('/alt-text');
 
   andThen(function() {
-    let noAltText = find('#no-alt-text')[0];
+    let noAltText = find('#img-no-alt-text')[0];
     assert.throws(function() {
       hasAltText(noAltText);
     }, /A11yError/);
@@ -70,7 +70,7 @@ test('allImagesHaveAltText passes', function(assert) {
   visit('/alt-text');
 
   andThen(function() {
-    let noAltText = find('#no-alt-text')[0];
+    let noAltText = find('#img-no-alt-text')[0];
     noAltText.setAttribute('alt', 'has alt now');
     assert.ok(allImagesHaveAltText());
   });
@@ -82,6 +82,28 @@ test('allImagesHaveAltText throws error', function(assert) {
   andThen(function() {
     assert.throws(function() {
       allImagesHaveAltText();
+    }, /A11yError/);
+  });
+});
+
+test('allNonTextElementsHaveAltText passes', function(assert) {
+  visit('/alt-text');
+
+  andThen(function() {
+    let noAltText = find('#img-no-alt-text, #audio-no-alt-text, #embed-no-alt-text, #object-no-alt-text, #video-no-alt-text, #canvas-no-alt-text');
+    for (let i = 0, l = noAltText.length; i < l; i++) {
+      noAltText[i].setAttribute('alt', 'has alt now');
+    }
+    assert.ok(allImagesHaveAltText());
+  });
+});
+
+test('allNonTextElementsHaveAltText throws error', function(assert) {
+  visit('/alt-text');
+
+  andThen(function() {
+    assert.throws(function() {
+      allNonTextElementsHaveAltText();
     }, /A11yError/);
   });
 });

--- a/tests/dummy/app/templates/alt-text.hbs
+++ b/tests/dummy/app/templates/alt-text.hbs
@@ -1,5 +1,35 @@
-<img id="no-alt-text">
-<img id="empty-alt-text" alt="">
-<img id="alt-text" alt="Has alt text">
-<img id="aria-hidden" aria-hidden="true">
-<img id="presentation" role="presentation">
+<img id="img-no-alt-text">
+<img id="img-empty-alt-text" alt="">
+<img id="img-alt-text" alt="Has alt text">
+<img id="img-aria-hidden" aria-hidden="true">
+<img id="img-presentation" role="presentation">
+
+<audio id="audio-no-alt-text"></audio>
+<audio id="audio-empty-alt-text" alt=""></audio>
+<audio id="audio-alt-text" alt="Has alt text"></audio>
+<audio id="audio-aria-hidden" aria-hidden="true"></audio>
+<audio id="audio-presentation" role="presentation"></audio>
+
+<object id="object-no-alt-text"></object>
+<object id="object-empty-alt-text" alt=""></object>
+<object id="object-alt-text" alt="Has alt text"></object>
+<object id="object-aria-hidden" aria-hidden="true"></object>
+<object id="object-presentation" role="presentation"></object>
+
+<canvas id="canvas-no-alt-text"></canvas>
+<canvas id="canvas-empty-alt-text" alt=""></canvas>
+<canvas id="canvas-alt-text" alt="Has alt text"></canvas>
+<canvas id="canvas-aria-hidden" aria-hidden="true"></canvas>
+<canvas id="canvas-presentation" role="presentation"></canvas>
+
+<video id="video-no-alt-text"></video>
+<video id="video-empty-alt-text" alt=""></video>
+<video id="video-alt-text" alt="Has alt text"></video>
+<video id="video-aria-hidden" aria-hidden="true"></video>
+<video id="video-presentation" role="presentation"></video>
+
+<embed id="embed-no-alt-text">
+<embed id="embed-empty-alt-text" alt="">
+<embed id="embed-alt-text" alt="Has alt text">
+<embed id="embed-aria-hidden" aria-hidden="true">
+<embed id="embed-presentation" role="presentation">


### PR DESCRIPTION
Hi! :smile_cat: 

In the todo section in the README, the following task was listed: "Alternative text for other elements (e.g., object, embed)". I looked up the elements where an alt attribute is recommended (rather than a name attribute, etc) and implemented a new method for this.

A few things of note:

1. For backwards compatibility, I've left in the img alt test. But if you'd prefer to just replace this method with my new one and bump this to a major version, let me know.

2. I created new test content for the dummy app to the best of my grokking abilities. 

2. There was a weird jquery version incompatibility issue preventing the tests from running locally or within Travis, so I went ahead and stepped down the version tolerance to solve this temporarily.

Thank you so much! :grin: 
