### PR TITLE
Add helper to verify focusability and visibility as a pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ ensures that they can receive focus.
 Note: _this check is DOM-based, and so only elements that use the Ember
 `{{action}}` helper will be checked_.
 
+### `allAreAllowedFocus`
+Finds all elements on the page that have a `tabindex` property assigned to them,
+and checks that they are visible. Although most browsers will intelligently turn off
+manually applied focusability for hidden elements under certain conditions
+(eg. `display:none`), this test is more liberal in order to be thorough.
+
 ## Todo List
 
 Below is the current list of proposed tests that will be built. Please feel free
@@ -127,6 +133,4 @@ this list.
 - [ ] Verify relationship of ARIA roles (radiogroup - radio, list - listitem,
 etc.)
 - [ ] Verify element is allowed to have ARIA attribute/role
-- [ ] Verify focusability and visibility (e.g., non-visible elements shouldn't
-be focusable)
 - [ ] Alternative text for other elements (e.g., `object`, `embed`)

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-a11y-testing",
   "dependencies": {
-    "jquery": "^1.11.1",
+    "jquery": "~1.11.1",
     "ember": "1.11.3",
     "ember-data": "1.0.0-beta.16.1",
     "ember-resolver": "~0.1.15",

--- a/test-support/helpers/a11y/helpers/focusable-visibility.js
+++ b/test-support/helpers/a11y/helpers/focusable-visibility.js
@@ -1,0 +1,51 @@
+/**
+ * Helpers related to verifying hidden content is not focusable.
+ * Reference: https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order
+ */
+
+import A11yError from '../a11y-error';
+
+/**
+ * Determines the visibility of an element.
+ * @param {HTMLElement} el - The element to test
+ * @return {Boolean}
+ */
+function checkIsVisible(el) {
+  return el && el.style.opacity !== 0 &&
+         el.style.visibility !== 'none' &&
+         el.style.display !== 'none' &&
+         el.style.height !== 0 &&
+         el.style.width !== 0 &&
+         el.getAttribute('type') !== 'hidden' &&
+         el.getAttribute('aria-hidden') !== 'true';
+}
+
+/**
+ * Checks a specific element to ensure it is allowed focus
+ * @param {Object} app - Not used
+ * @param {HTMLElement} el - The element to check
+ * @return {Boolean|Error}
+ */
+export function isAllowedFocus(app, el) {
+  let isVisible = checkIsVisible(el);
+  // console.log('isvis'+ isVisible);
+  if (isVisible) {
+    return true;
+  }
+
+  throw new A11yError(el, `The element is hidden, but still focusable. Remove the tabindex attribute to ensure focus won't occur.`);
+}
+
+/**
+ * Checks all elements on the page to make sure they are allowed focus
+ * @return {Boolean|Error}
+ */
+export function allAreAllowedFocus() {
+  let focusable = document.querySelectorAll('[tabindex]');
+
+  for (let i = 0, l = focusable.length; i < l; i++) {
+    isAllowedFocus(null, focusable[i]);
+  }
+
+  return true;
+}

--- a/test-support/helpers/a11y/helpers/focusable-visibility.js
+++ b/test-support/helpers/a11y/helpers/focusable-visibility.js
@@ -28,7 +28,6 @@ function checkIsVisible(el) {
  */
 export function isAllowedFocus(app, el) {
   let isVisible = checkIsVisible(el);
-  // console.log('isvis'+ isVisible);
   if (isVisible) {
     return true;
   }

--- a/test-support/helpers/a11y/register-a11y-helpers.js
+++ b/test-support/helpers/a11y/register-a11y-helpers.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 import { hasAltText, allImagesHaveAltText } from './helpers/alt-text';
+import { isAllowedFocus, allAreAllowedFocus } from './helpers/focusable-visibility';
 import { checkAriaHidden, checkForNoRead } from './helpers/no-read';
 import { hasLabel, formHasAllNeededLabels, allFormsHaveLabels } from './helpers/form-labels';
 import { verifyRequiredAria, verifySupportedAria, checkAriaRoles } from './helpers/aria-properties';
@@ -17,7 +18,9 @@ const TEST_FUNCTIONS = [
   checkIds,
   checkLinks,
   checkAllTextContrast,
-  allActionsFocusable
+  allActionsFocusable,
+  isAllowedFocus,
+  allAreAllowedFocus
 ];
 
 const DEFAULT_CONFIG = {
@@ -28,7 +31,8 @@ const DEFAULT_CONFIG = {
   checkIds: true,
   checkLinks: true,
   checkAllTextContrast: false,
-  allActionsFocusable: true
+  allActionsFocusable: true,
+  allAreAllowedFocus: true
 };
 
 /**
@@ -96,4 +100,8 @@ export default function registerA11yHelpers() {
   // actions
   Ember.Test.registerHelper('actionIsFocusable', actionIsFocusable);
   Ember.Test.registerHelper('allActionsFocusable', allActionsFocusable);
+
+  // focusable visibility
+  Ember.Test.registerHelper('isAllowedFocus', isAllowedFocus);
+  Ember.Test.registerHelper('allAreAllowedFocus', allAreAllowedFocus);
 }

--- a/tests/acceptance/focusable-visibility-test.js
+++ b/tests/acceptance/focusable-visibility-test.js
@@ -1,0 +1,71 @@
+/* global isAllowedFocus, allAreAllowedFocus */
+
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from '../helpers/start-app';
+
+let application;
+
+module('Acceptance: focusable-visibility', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('isAllowedFocus passes on visible span', function(assert) {
+  visit('/focusable-visibility');
+
+  andThen(function() {
+    let visibleElement = document.querySelectorAll('#visible-element')[0];
+    assert.ok(isAllowedFocus(visibleElement));
+  });
+});
+
+test('isAllowedFocus passes on aria visible text field', function(assert) {
+  visit('/focusable-visibility');
+
+  andThen(function() {
+    let visibleElement = document.querySelectorAll('#not-aria-hidden')[0];
+    assert.ok(isAllowedFocus(visibleElement));
+  });
+});
+
+test('isAllowedFocus throws error', function(assert) {
+  visit('/focusable-visibility');
+
+  andThen(function() {
+    let hiddenElement = find('#hidden-field')[0];
+    assert.throws(function() {
+      isAllowedFocus(hiddenElement);
+    }, /A11yError/);
+  });
+});
+
+test('allAreAllowedFocus passes', function(assert) {
+  visit('/focusable-visibility');
+
+  andThen(function() {
+    let failingElements = find('#display-none, #visibility-none, #height-none, #width-none, #opacity-none, #hidden-field, #aria-hidden');
+    for (let i = 0, l = failingElements.length; i < l; i++) {
+      failingElements[i].removeAttribute('tabindex');
+    }
+    assert.ok(allAreAllowedFocus());
+  });
+});
+
+test('allAreAllowedFocus throws error', function(assert) {
+  visit('/focusable-visibility');
+
+  andThen(function() {
+    assert.throws(function() {
+      allAreAllowedFocus();
+    }, /A11yError/);
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,6 +15,7 @@ Router.map(function() {
   this.route('links');
   this.route('color-contrast');
   this.route('actions');
+  this.route('focusable-visibility');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/focusable-visibility.hbs
+++ b/tests/dummy/app/templates/focusable-visibility.hbs
@@ -1,0 +1,9 @@
+{{link-to "a11y test" "a11y-test" id="display-none" style="display:none" tabindex="1"}}
+<input type="text" id="visibility-none" style="visibility:none" tabindex="1"/>
+<input type="text" id="height-none" style="height:0" tabindex="1"/>
+<input type="text" id="width-none" style="width:0" tabindex="1"/>
+<input type="text" id="opacity-none" style="opacity:0" tabindex="1"/>
+<input type="hidden" id="hidden-field" tabindex="1"/>
+<input type="text" id="aria-hidden" aria-hidden="true" tabindex="1"/>
+<input type="text" id="not-aria-hidden" aria-hidden="false" tabindex="1"/>
+<span id="visible-element" tabindex="-1">Focus me</span>


### PR DESCRIPTION
Hello again :smile:

In the todo section in the README, the following task was listed: "Verify focusability and visibility (e.g., non-visible elements shouldn't be focusable)". I implemented a new method / helper for this.

A few things of note:

1. This new test helper is a greedy one -  it covers lots of conditions for whether an element is hidden (regardless of whether the browser compensates focus management for you). Before this it matches for a `tabindex` property attached to any element. Can you think of any cases where this might not catch something?

2. Let me know if you feel the logic might be better reversed - that is, grabbing all hidden elements, and making sure there's no `tabindex` assigned. I wrote it this way for cleaner code / use of a greedy selector, but happy to change it if it reads better. I wish jQuery's `:hidden` selector was native!

3. I created new test content for the dummy app and acceptance tests.

4. I cherry-picked the weird jQuery version incompatibility issue fix from a previous pull request just to get the tests passing. I can rebase this out if needed.

Thank you so much again for this Ember add-on! :bow: 