### PR TITLE
Fix typo in combobox for aria role autocomplete

### DIFF
--- a/test-support/helpers/a11y/utils/wai-aria-map.js
+++ b/test-support/helpers/a11y/utils/wai-aria-map.js
@@ -46,7 +46,7 @@ export const ARIA_MAP = {
   },
   combobox: {
     required: [ 'expanded' ],
-    supported: [ 'autocomplet', 'require', 'activedescendant' ]
+    supported: [ 'autocomplete', 'require', 'activedescendant' ]
   },
   complementary: {
     supported: [ 'expanded' ]


### PR DESCRIPTION
Was looking for the way we import axe-core, was surprised to see a copied file here.

https://embercommunity.slack.com/archives/topic-a11y/p1463595296001123